### PR TITLE
Allow circular symlinks when dereference option is false

### DIFF
--- a/lib/copy/copy-sync.js
+++ b/lib/copy/copy-sync.js
@@ -148,16 +148,17 @@ function onLink (destStat, src, dest, opts) {
     }
     if (opts.dereference) {
       resolvedDest = path.resolve(process.cwd(), resolvedDest)
-    }
-    if (stat.isSrcSubdir(resolvedSrc, resolvedDest)) {
-      throw new Error(`Cannot copy '${resolvedSrc}' to a subdirectory of itself, '${resolvedDest}'.`)
-    }
+    
+      if (stat.isSrcSubdir(resolvedSrc, resolvedDest)) {
+        throw new Error(`Cannot copy '${resolvedSrc}' to a subdirectory of itself, '${resolvedDest}'.`)
+      }
 
-    // prevent copy if src is a subdir of dest since unlinking
-    // dest in this case would result in removing src contents
-    // and therefore a broken symlink would be created.
-    if (stat.isSrcSubdir(resolvedDest, resolvedSrc)) {
-      throw new Error(`Cannot overwrite '${resolvedDest}' with '${resolvedSrc}'.`)
+      // prevent copy if src is a subdir of dest since unlinking
+      // dest in this case would result in removing src contents
+      // and therefore a broken symlink would be created.
+      if (stat.isSrcSubdir(resolvedDest, resolvedSrc)) {
+        throw new Error(`Cannot overwrite '${resolvedDest}' with '${resolvedSrc}'.`)
+      }
     }
     return copyLink(resolvedSrc, dest)
   }


### PR DESCRIPTION
When copying certain directory structures with circular symlinks, the copy operation will fail due to `Error: Cannot copy '.' to a subdirectory of itself, '.'.` This is an issue when dereferencing the symlinks, but we are not using that option.

This moves the error check into the dereference option only, so that these valid symlinks can be created. v5.0.0 of the node module `locate-path` has this symlink structure in place for testing:

```sh
$ ls -la locate-path@5.0.0/fixture
total 0
drwxr-xr-x@  5 robszumski  staff  160 Jun 28 10:44 .
drwxr-xr-x@ 15 robszumski  staff  480 Jun 28 10:44 ..
lrwxr-xr-x@  1 robszumski  staff    1 Jun 28 10:44 directory-link -> .
lrwxr-xr-x@  1 robszumski  staff    7 Jun 28 10:44 file-link -> unicorn
-rw-r--r--@  1 robszumski  staff    0 Jun 28 10:44 unicorn
```